### PR TITLE
bump required Php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below you'll find a list of features as well as a roadmap with features we will 
 
 ## Supported Versions
 
-The extension supports all Laravel versions currently listed under the [Support Policy](https://laravel.com/docs/releases#support-policy) and requires PHP >= 8.0 to run.
+The extension supports all Laravel versions currently listed under the [Support Policy](https://laravel.com/docs/releases#support-policy) and the minimum Php version is 8.2.
 
 ## Features
 


### PR DESCRIPTION
Laravel 10 was supported until February 4th, 2025.

The parser requires Php 8.2, and will throw errors on previous versions.


**An example of an error that can happen:**

getClosureUsedVariables was added in Php 8.1. Due to it not existing in Php 8.0 it fails.

```
Error: __VSCODE_LARAVEL_START_OUTPUT__
   Error 

  Call to undefined method ReflectionFunction::getClosureUsedVariables()

  at vendor/_laravel_ide/discover-ea280fb1636eb761c4fd23f76666e397.php:134
    130▕                         $closureThis = $reflection->getClosureThis();
    131▕ 
    132▕                         if ($closureThis !== null) {
    133▕                             if (get_class($closureThis) === \Illuminate\Auth\Access\Gate::class) {
  ➜ 134▕                                 $vars = $reflection->getClosureUsedVariables();
    135▕ 
    136▕                                 if (isset($vars['callback'])) {
    137▕                                     [$policyClass, $method] = explode('@', $vars['callback']);
    138▕

```

